### PR TITLE
Correction of errors to Python 3

### DIFF
--- a/xhtml2pdf/reportlab_paragraph.py
+++ b/xhtml2pdf/reportlab_paragraph.py
@@ -116,12 +116,12 @@ _wsc_re_split = re.compile('[%s]+' % re.escape(''.join((
 
 
 def split(text, delim=None):
-    if type(text) is str:
+    if type(text) != unicode:
         try:
             text = text.decode('utf8')
         except Exception:
             pass
-    if type(delim) is str:
+    if type(delim) != unicode:
         try:
             delim = delim.decode('utf8')
         except Exception:
@@ -132,7 +132,7 @@ def split(text, delim=None):
 
 
 def strip(text):
-    if type(text) is str:
+    if type(text) is unicode:
         try:
             text = text.decode('utf8')
         except Exception:
@@ -496,7 +496,10 @@ def _getFragWords(frags):
     n = 0
     hangingStrip = False
     for f in frags:
-        text = f.text
+        if type(f.text) != unicode:
+            text = f.text.decode()
+        else:
+            text = f.text
         # of paragraphs
         if text != '':
             if hangingStrip:
@@ -582,7 +585,10 @@ def _split_blParaHard(blPara, start, stop):
                 if not g.text:
                     g.text = ' '
                 elif g.text[-1] != ' ':
-                    g.text += ' '
+                    if type(g.text) != unicode:
+                        g.text += ' '.encode()
+                    else:
+                        g.text += ' '
     return f
 
 

--- a/xhtml2pdf/util.py
+++ b/xhtml2pdf/util.py
@@ -507,7 +507,11 @@ class pisaTempFile(object):
             try:
                 value = value.decode("utf-8")
             except UnicodeDecodeError:
-                pass
+                try:
+                    value = value.decode("ISO-8859-1")
+                except UnicodeDecodeError:
+                    pass
+
         self._delegate.write(value)
 
     def __getattr__(self, name):


### PR DESCRIPTION
Hey , we know what it is to deal with the different types of data, and plus a lenguje that evolved as python and has 2 fully stable releases.

I want to ask you a favor , for using python 2 and why not also for python 3; realizen whenever a change , take the trouble to check their equivalence in both versions.

Do not let the library is damaged or fails to serve for ill-structured changes.

I use python 2, but my projects evolved , now using python 3 and give support for this, we maintain a standard .

With all respect , I say goodbye .
Excuse my bad English.